### PR TITLE
Added Vagrant and Puppet scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
 roswiki_vagrant
 ===============
+A set of Vagrant and Puppet scripts to deploy and test roswiki in a VM.
+
+Requirements
+============
+
+The only requirements of roswiki_vagrant are just Vagrant and Virtualbox.
+
+Virtualbox
+----------
+The most recent version of Virtualbox can be installed from
+https://www.virtualbox.org/wiki/Downloads, make sure to install VirtualBox Extension Pack too.
+
+
+Vagrant
+-------
+The Vagrant team provides Debian packages available from their
+website: http://www.vagrantup.com/downloads.html
+
+vagrant-vbguest
+---------------
+Vagrant needs the Virtualbox Guest Additions to be in sync with the version of
+Virtualbox installed on the host. The vagrant-vbguest plugin checks that the
+version of the Virtualbox Guest Additions matches and installs the most recent
+version if needed.
+
+To install vagrant-vbguest just type:
+
+```
+$ vagrant plugin install vagrant-vbguest
+```
+
+
+Usage
+=====
+Checkout this repository and roswiki's side by side, so both copies are siblings and
+type the following from the roswiki_vagrant directory to start the VM:
+
+```
+$ vagrant up
+```
+
+After a few minutes, the VM should be running and fully provisioned with an empty wiki.
+To access the wiki, point your web browser to http://localhost:8080, If desired, the port
+can be changed in Vagrantfile:
+
+```
+config.vm.network "forwarded_port", guest: 8080, host: 8080
+```
+
+where guest is the port where Apache listens inside the VM and host the port that is
+accessible from the web browser.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "precise64"
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vbguest.auto_update = true
+
+  config.vm.provider "virtualbox" do |vb|
+    vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
+    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "off"]
+  end
+
+  config.vm.provision :shell, :path => "shell/main.sh"
+
+  config.vm.provision :puppet do |puppet|
+    puppet.manifests_path = "puppet/manifests"
+    puppet.manifest_file  = "site.pp"
+    puppet.module_path = ['puppet/modules-contrib', 'puppet/modules' ]
+  end
+
+  config.vm.box = "precise64"
+
+  config.vm.network "forwarded_port", guest: 8080, host: 8080
+
+  config.vm.synced_folder "../roswiki/", "/vagrant-roswiki"
+end

--- a/puppet/.gitignore
+++ b/puppet/.gitignore
@@ -1,0 +1,3 @@
+.tmp
+.librarian
+Puppetfile.lock

--- a/puppet/Puppetfile
+++ b/puppet/Puppetfile
@@ -1,0 +1,7 @@
+# Configuration for librarian-puppet. For example:
+# 
+forge "http://forge.puppetlabs.com"
+# 
+mod "puppetlabs/apt"
+mod "puppetlabs/vcsrepo"
+mod "stankevich/python"

--- a/puppet/manifests/roswiki.pp
+++ b/puppet/manifests/roswiki.pp
@@ -1,0 +1,108 @@
+node default {
+   class { 'python':
+        version => 'system',
+        dev => true,
+        virtualenv => true,
+    }
+
+    package {                                                                                                                                                                                                                                                                  
+        'apache2': ensure => latest;                                                                                                                                                                                                                                   
+        'libapache2-mod-wsgi': ensure => latest;
+    }
+
+    vcsrepo { '/var/www/wiki.ros.org/conf':
+        ensure => present,
+        provider => git,
+        source => 'git://github.com/ros-infrastructure/roswiki.git',
+        revision => 'conf',
+    }    
+
+    file { '/var/www/wiki.ros.org/data/plugin':
+        source => '/vagrant-roswiki',
+        recurse => true,
+        owner => www-data,
+        group => www-data,
+        ignore => ['.git', '*.pyc'],
+    }    
+
+    file { '/etc/apache2/sites-available/wiki.ros.org.conf':
+        content => template('roswiki/wiki.ros.org.conf.erb'),
+        require => Package['apache2'],
+        notify => Service['apache2'],
+    }
+
+    file { '/etc/apache2/sites-enabled/wiki.ros.org.conf':
+        ensure => 'link',
+        target => '/etc/apache2/sites-available/wiki.ros.org.conf',
+        notify => Service['apache2'],
+        require => File['/etc/apache2/sites-available/wiki.ros.org.conf'],
+    }
+
+    file { '/etc/apache2/ports.conf':
+        content => template('roswiki/ports.conf.erb'),
+        require => Package['apache2'],
+        notify => Service['apache2'],
+    }
+
+    file { '/etc/apache2/sites-enabled/000-default':
+        ensure => absent,
+        notify => Service['apache2'],
+        require => Package['apache2'],
+    }
+
+    file { '/etc/apache2/mods-enabled/rewrite.load':
+        ensure => 'link',
+        target => '/etc/apache2/mods-available/rewrite.load',
+        notify => Service['apache2'],
+        require => Package['apache2'],
+    }
+
+    file { '/etc/apache2/mods-enabled/wsgi.load':
+        ensure => 'link',
+        target => '/etc/apache2/mods-available/wsgi.load',
+        notify => Service['apache2'],
+        require => Package['libapache2-mod-wsgi'],
+    }
+
+    service { 'apache2':
+        ensure => running,
+        require => Package['apache2'],
+    }
+
+    file { ['/var/www/wiki.ros.org/underlay', '/var/www/wiki.ros.org/underlay/pages',
+        '/var/www/wiki.ros.org/data', '/var/www/wiki.ros.org/data/pages',
+        '/var/www/wiki.ros.org/data/user', '/var/log/apache2/wiki.ros.org',
+        '/var/log/apache2/wiki.ros.org/access', '/var/log/apache2/wiki.ros.org/error']:
+        owner => 'www-data',
+        group => 'www-data',
+        ensure => directory,
+    }
+
+    python::virtualenv { '/var/www/wiki.ros.org/venv':
+        ensure => present,
+        owner => 'www-data',
+        group => 'www-data',
+        require => [File['/var/www/wiki.ros.org/data/plugin'], File['/var/www/wiki.ros.org']],
+    } 
+
+    python::pip { 'newrelic':
+        pkgname => 'newrelic',
+        virtualenv => '/var/www/wiki.ros.org/venv',
+        require => [Python::Virtualenv['/var/www/wiki.ros.org/venv'], Package['python-dev']],
+        owner => 'www-data',
+    }
+
+    python::pip { 'moin':
+        pkgname => 'moin',
+        virtualenv => '/var/www/wiki.ros.org/venv',
+        require => Python::Virtualenv['/var/www/wiki.ros.org/venv'],
+        owner => 'www-data',
+        install_args => ['--allow-external moin --allow-unverified moin'],
+    }
+
+    file { '/var/www/wiki.ros.org':
+        ensure => directory,
+        owner => www-data,
+        group => www-data,
+    }
+}

--- a/puppet/manifests/site.pp
+++ b/puppet/manifests/site.pp
@@ -1,0 +1,1 @@
+import 'roswiki.pp'

--- a/puppet/modules-contrib/.gitignore
+++ b/puppet/modules-contrib/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/puppet/modules/roswiki/templates/ports.conf.erb
+++ b/puppet/modules/roswiki/templates/ports.conf.erb
@@ -1,0 +1,2 @@
+Listen 8080
+NameVirtualHost *:8080

--- a/puppet/modules/roswiki/templates/wiki.ros.org.conf.erb
+++ b/puppet/modules/roswiki/templates/wiki.ros.org.conf.erb
@@ -1,0 +1,28 @@
+<VirtualHost *:8080>
+  ServerName wiki.ros.org
+  ServerAlias wiki.ros.osuosl.org
+
+  DocumentRoot /var/www/wiki.ros.org/data
+  RewriteEngine On
+
+  Redirect permanent /ros /ROS
+
+  <Directory "/var/www/wiki.ros.org/data">
+    Options Indexes FollowSymLinks MultiViews
+    AllowOverride All
+    Order allow,deny
+    Allow from all
+  </Directory>
+
+  Alias /custom/ "/var/www/wiki.ros.org/data/plugin/custom/"
+  Alias /moin_static197/rostheme/ "/var/www/wiki.ros.org/data/plugin/custom/rostheme/"
+  Alias /moin_static197/ "/var/www/wiki.ros.org/venv/lib/python2.7/site-packages/MoinMoin/web/static/htdocs/"
+
+  WSGIScriptAlias / /var/www/wiki.ros.org/conf/moin.wsgi
+  WSGIDaemonProcess wgmoin user=www-data group=www-data display-name='%{GROUP}' home=/var/www/wiki.ros.org/data/ processes=10 threads=1 maximum-requests=1000 umask=0007 python-path=/var/www/wiki.ros.org/venv/lib/python2.7/site-packages/
+  WSGIProcessGroup wgmoin
+
+  LogFormat "%h %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-agent}i\"" simple
+  CustomLog "|/usr/sbin/rotatelogs /var/log/apache2/wiki.ros.org/access/%Y%m%d.log 86400" simple
+  ErrorLog "|/usr/sbin/rotatelogs /var/log/apache2/wiki.ros.org/error/%Y%m%d.log 86400"
+</VirtualHost>

--- a/shell/main.sh
+++ b/shell/main.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+# Directory in which librarian-puppet should manage its modules directory
+PUPPET_DIR=/vagrant/puppet
+
+# NB: librarian-puppet might need git installed. If it is not already installed
+# in your basebox, this will manually install it at this point using apt or yum
+
+$(which git > /dev/null 2>&1)
+FOUND_GIT=$?
+$(which apt-get > /dev/null 2>&1)
+FOUND_APT=$?
+$(which yum > /dev/null 2>&1)
+FOUND_YUM=$?
+
+if [ "${FOUND_APT}" -eq '0' ]; then
+  apt-get -q -y update
+  apt-get -q -y install ruby-json libaugeas-dev pkg-config
+  echo 'ruby-json and augeas installed.'
+fi
+
+if [ "$FOUND_GIT" -ne '0' ]; then
+  echo 'Attempting to install git.'
+
+  if [ "${FOUND_YUM}" -eq '0' ]; then
+    yum -q -y makecache
+    yum -q -y install git
+    echo 'git installed.'
+  elif [ "${FOUND_APT}" -eq '0' ]; then
+    apt-get -q -y install git
+    echo 'git installed.'
+  else
+    echo 'No package installer available. You may need to install git manually.'
+  fi
+else
+  echo 'git found.'
+fi
+
+if [ "$(gem search -i rubygems-update)" = "false" ]; then
+  gem install rubygems-update --no-rdoc --no-ri
+else
+  gem update rubygems-update --no-rdoc --no-ri
+fi
+
+gem update --system --no-rdoc --no-ri
+
+if [ "$(gem search -i ruby-augeas)" = "false" ]; then
+  gem install ruby-augeas --no-rdoc --no-ri
+else
+  gem update ruby-augeas --no-rdoc --no-ri
+fi
+
+if [ "$(gem search -i puppet)" = "false" ]; then
+  gem install puppet --no-rdoc --no-ri
+else
+  gem update puppet --no-rdoc --no-ri
+fi
+
+if [ "$(gem search -i librarian-puppet)" = "false" ]; then
+  gem install librarian-puppet --no-rdoc --no-ri
+  cd $PUPPET_DIR && librarian-puppet install --path modules-contrib
+else
+  cd $PUPPET_DIR && librarian-puppet update
+fi


### PR DESCRIPTION
This branch adds the Vagrant and Puppet scripts in order to deploy and test the roswiki macros and configuration in a VM. It needs a copy of the roswiki repository in the same parent directory.

Please review, @dirk-thomas @tfoote @wjwwood
